### PR TITLE
Workana Development Branch

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: |
+        composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+        composer install --prefer-dist --no-progress --ignore-platform-req=php
+
+    - name: Run test suite
+      run: vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,6 +19,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-php-
 
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.4
+
     - name: Install dependencies
       run: |
         composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: PHP Composer
 
 on:
   push:
@@ -7,7 +7,9 @@ on:
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v2
     - name: Cache Composer packages
@@ -20,9 +22,7 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Install dependencies
-      run: |
-        composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
-        composer install --prefer-dist --no-progress --ignore-platform-req=php
+      run: composer install --prefer-dist --no-progress
 
     - name: Run test suite
-      run: vendor/bin/phpunit
+      run: composer run-script test

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: Tests
 
 on:
   push:
@@ -22,7 +22,9 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
+      run: |
+        composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+        composer install --prefer-dist --no-progress --ignore-platform-req=php
 
     - name: Run test suite
-      run: composer run-script test
+      run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "aws/aws-sdk-php": "~2.4|~3.0",
         "pda/pheanstalk": "~3.0",
         "php-amqplib/php-amqplib": "~2.5",
-        "phpspec/phpspec": "^2.4",
+        "phpspec/phpspec": "^4.3",
         "phpunit/phpunit": "^5.5|^6.0",
         "iron-io/iron_mq": "~4.0",
         "league/container": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "bernard/normalt": "~1.0",
-        "symfony/event-dispatcher": "^2.7|^3.0|^4.0",
+        "symfony/event-dispatcher": "^4.0",
         "beberlei/assert": "~2.1"
     },
     "require-dev" : {

--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -62,7 +62,7 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function getQueue($queue)
     {
-        if (count($queue) > 1) {
+        if (!is_string($queue) && count($queue) > 1) {
             $queues = array_map([$this->queues, 'create'], $queue);
 
             return new RoundRobinQueue($queues);

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -76,7 +76,7 @@ class Consumer
             return true;
         }
 
-        $this->dispatcher->dispatch(BernardEvents::PING, new PingEvent($queue));
+        $this->dispatcher->dispatch(new PingEvent($queue), BernardEvents::PING);
 
         if (!$envelope = $queue->dequeue()) {
             return !$this->options['stop-when-empty'];
@@ -128,7 +128,7 @@ class Consumer
     public function invoke(Envelope $envelope, Queue $queue)
     {
         try {
-            $this->dispatcher->dispatch(BernardEvents::INVOKE, new EnvelopeEvent($envelope, $queue));
+            $this->dispatcher->dispatch(new EnvelopeEvent($envelope, $queue), BernardEvents::INVOKE);
 
             // for 5.3 support where a function name is not a callable
             call_user_func($this->router->map($envelope), $envelope->getMessage());
@@ -136,7 +136,7 @@ class Consumer
             // We successfully processed the message.
             $queue->acknowledge($envelope);
 
-            $this->dispatcher->dispatch(BernardEvents::ACKNOWLEDGE, new EnvelopeEvent($envelope, $queue));
+            $this->dispatcher->dispatch(new EnvelopeEvent($envelope, $queue), BernardEvents::ACKNOWLEDGE);
         } catch (\Throwable $error) {
             $this->rejectDispatch($error, $envelope, $queue);
         } catch (\Exception $exception) {
@@ -193,7 +193,7 @@ class Consumer
         // Previously failing jobs handling have been moved to a middleware.
         //
         // Emit an event to let others log that exception
-        $this->dispatcher->dispatch(BernardEvents::REJECT, new RejectEnvelopeEvent($envelope, $queue, $exception));
+        $this->dispatcher->dispatch(new RejectEnvelopeEvent($envelope, $queue, $exception), BernardEvents::REJECT);
 
         if ($this->options['stop-on-error']) {
             throw $exception;

--- a/src/DelayableDriver.php
+++ b/src/DelayableDriver.php
@@ -1,0 +1,18 @@
+<?php
+namespace Bernard;
+
+/**
+ * @package Bernard
+ * @author Carlos Frutos <charly@workana.com>
+ */
+interface DelayableDriver extends Driver
+{
+    /**
+     * Insert a message with delay
+     *
+     * @param string    $queueName
+     * @param string    $message
+     * @param int       $delay         Delay in seconds
+     */
+    public function pushMessageWithDelay($queueName, $message, $delay);
+}

--- a/src/Driver/Delayable/DelayablePheanstalkDriver.php
+++ b/src/Driver/Delayable/DelayablePheanstalkDriver.php
@@ -1,0 +1,28 @@
+<?php
+namespace Bernard\Driver\Delayable;
+
+use Bernard\Driver\PheanstalkDriver;
+use Bernard\DelayableDriver;
+use Pheanstalk\PheanstalkInterface;
+
+/**
+ * Delayable Pheanstalk Driver
+ *
+ * @package Bernard
+ * @author Carlos Frutos <charly@workana.com>
+ */
+class DelayablePheanstalkDriver extends PheanstalkDriver implements DelayableDriver
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function pushMessageWithDelay($queueName, $message, $delay)
+    {
+        $this->pheanstalk->putInTube(
+            $queueName,
+            $message,
+            PheanstalkInterface::DEFAULT_PRIORITY,
+            (int) $delay
+        );
+    }
+}

--- a/src/Envelope.php
+++ b/src/Envelope.php
@@ -2,6 +2,8 @@
 
 namespace Bernard;
 
+use Bernard\Exception\InvalidOperationException;
+
 /**
  * Wraps a Message with metadata that can be used for automatic retry
  * or inspection.
@@ -13,13 +15,20 @@ class Envelope
     protected $message;
     protected $class;
     protected $timestamp;
+    protected $delay;
 
     /**
-     * @param Message $message
+     * @param Message   $message
+     * @param int       $delay      Delay (in seconds)
      */
-    public function __construct(Message $message)
+    public function __construct(Message $message, $delay = 0)
     {
+        if ((int) $delay < 0) {
+            throw new InvalidOperationException('Delay must be greater or equal than zero');
+        }
+
         $this->message = $message;
+        $this->delay  = (int) $delay;
         $this->class = get_class($message);
         $this->timestamp = time();
     }
@@ -30,6 +39,22 @@ class Envelope
     public function getMessage()
     {
         return $this->message;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDelayed()
+    {
+        return ($this->delay > 0);
+    }
+
+    /**
+     * @return int
+     */
+    public function getDelay()
+    {
+        return $this->delay;
     }
 
     /**

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -26,13 +26,14 @@ class Producer
     /**
      * @param Message     $message
      * @param string|null $queueName
+     * @param int         $delay        Delay (in seconds)
      */
-    public function produce(Message $message, $queueName = null)
+    public function produce(Message $message, $queueName = null, $delay = 0)
     {
         $queueName = $queueName ?: Util::guessQueue($message);
 
         $queue = $this->queues->create($queueName);
-        $queue->enqueue($envelope = new Envelope($message));
+        $queue->enqueue($envelope = new Envelope($message, $delay));
 
         $this->dispatcher->dispatch(BernardEvents::PRODUCE, new EnvelopeEvent($envelope, $queue));
     }

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -35,6 +35,6 @@ class Producer
         $queue = $this->queues->create($queueName);
         $queue->enqueue($envelope = new Envelope($message, $delay));
 
-        $this->dispatcher->dispatch(BernardEvents::PRODUCE, new EnvelopeEvent($envelope, $queue));
+        $this->dispatcher->dispatch(new EnvelopeEvent($envelope, $queue), BernardEvents::PRODUCE);
     }
 }

--- a/src/QueueFactory/InMemoryFactory.php
+++ b/src/QueueFactory/InMemoryFactory.php
@@ -12,7 +12,7 @@ use Bernard\Queue\InMemoryQueue;
  */
 class InMemoryFactory implements \Bernard\QueueFactory
 {
-    protected $queues;
+    protected $queues = [];
 
     /**
      * {@inheritdoc}

--- a/src/QueueFactory/PersistentFactory.php
+++ b/src/QueueFactory/PersistentFactory.php
@@ -67,7 +67,11 @@ class PersistentFactory implements \Bernard\QueueFactory
      */
     public function count()
     {
-        return count($this->driver->listQueues());
+        $queues = $this->driver->listQueues();
+        if (null === $queues) {
+            return  0;
+        }
+        return count($queues);
     }
 
     /**

--- a/tests/Driver/Delayable/DelayablePheanstalkDriverTest.php
+++ b/tests/Driver/Delayable/DelayablePheanstalkDriverTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace Bernard\Tests\Driver\Delayable;
+
+use Bernard\Driver\Delayable\DelayablePheanstalkDriver;
+use Pheanstalk\PheanstalkInterface;
+
+class DelayablePheanstalkDriverTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->pheanstalk = $this->getMockBuilder('Pheanstalk\Pheanstalk')
+            ->setMethods(array(
+                'putInTube'
+            ))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->driver = new DelayablePheanstalkDriver($this->pheanstalk);
+    }
+
+    public function testItPushesMessagesWithDelay()
+    {
+        $this->pheanstalk
+            ->expects($this->once())
+            ->method('putInTube')
+            ->with(
+                $this->equalTo('my-queue'),
+                $this->equalTo('This is a message'),
+                $this->equalTo(PheanstalkInterface::DEFAULT_PRIORITY),
+                $this->equalTo(10)
+            );
+
+        $this->driver->pushMessageWithDelay('my-queue', 'This is a message', 10);
+    }
+}

--- a/tests/Driver/Delayable/DelayablePheanstalkDriverTest.php
+++ b/tests/Driver/Delayable/DelayablePheanstalkDriverTest.php
@@ -3,8 +3,9 @@ namespace Bernard\Tests\Driver\Delayable;
 
 use Bernard\Driver\Delayable\DelayablePheanstalkDriver;
 use Pheanstalk\PheanstalkInterface;
+use PHPUnit\Framework\TestCase;
 
-class DelayablePheanstalkDriverTest extends \PHPUnit_Framework_TestCase
+class DelayablePheanstalkDriverTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/EnvelopeTest.php
+++ b/tests/EnvelopeTest.php
@@ -16,4 +16,27 @@ class EnvelopeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('SendNewsletter', $envelope->getName());
         $this->assertSame($message, $envelope->getMessage());
     }
+
+    public function testNotDelayedMetadata()
+    {
+        $envelope = new Envelope($message = new DefaultMessage('SendNewsletter'));
+        $this->assertFalse($envelope->isDelayed());
+        $this->assertEquals(0, $envelope->getDelay());
+    }
+
+    public function testDelayedMetadata()
+    {
+        $envelope = new Envelope($message = new DefaultMessage('SendNewsletter'), 10);
+        $this->assertTrue($envelope->isDelayed());
+        $this->assertEquals(10, $envelope->getDelay());
+    }
+
+    /**
+     * @expectedException Bernard\Exception\InvalidOperationException
+     * @expectedExceptionMessage Delay must be greater or equal than zero
+     */
+    public function testNegativeDelay()
+    {
+        $envelope = new Envelope($message = new DefaultMessage('SendNewsletter'), -10);
+    }
 }

--- a/tests/EnvelopeTest.php
+++ b/tests/EnvelopeTest.php
@@ -2,6 +2,7 @@
 
 namespace Bernard\Tests;
 
+use Bernard\Message\DefaultMessage;
 use Bernard\Message\PlainMessage;
 use Bernard\Envelope;
 

--- a/tests/EnvelopeTest.php
+++ b/tests/EnvelopeTest.php
@@ -16,4 +16,27 @@ class EnvelopeTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('SendNewsletter', $envelope->getName());
         $this->assertSame($message, $envelope->getMessage());
     }
+
+    public function testNotDelayedMetadata()
+    {
+        $envelope = new Envelope($message = new DefaultMessage('SendNewsletter'));
+        $this->assertFalse($envelope->isDelayed());
+        $this->assertEquals(0, $envelope->getDelay());
+    }
+
+    public function testDelayedMetadata()
+    {
+        $envelope = new Envelope($message = new DefaultMessage('SendNewsletter'), 10);
+        $this->assertTrue($envelope->isDelayed());
+        $this->assertEquals(10, $envelope->getDelay());
+    }
+
+    /**
+     * @expectedException Bernard\Exception\InvalidOperationException
+     * @expectedExceptionMessage Delay must be greater or equal than zero
+     */
+    public function testNegativeDelay()
+    {
+        $envelope = new Envelope($message = new DefaultMessage('SendNewsletter'), -10);
+    }
 }

--- a/tests/ProducerTest.php
+++ b/tests/ProducerTest.php
@@ -43,6 +43,18 @@ class ProducerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($message, $envelope->getMessage());
     }
 
+    public function testWithDelay()
+    {
+        $message = new DefaultMessage('SendNewsletter');
+
+        $this->producer->produce($message, null, 10);
+
+        $envelope = $this->queues->create('send-newsletter')->dequeue();
+
+        $this->assertTrue($envelope->isDelayed());
+        $this->assertEquals(10, $envelope->getDelay());
+    }
+
     public function testItUsesGivenQueueName()
     {
         $message = new DefaultMessage('SendNewsletter');

--- a/tests/ProducerTest.php
+++ b/tests/ProducerTest.php
@@ -2,6 +2,7 @@
 
 namespace Bernard\Tests;
 
+use Bernard\Message\DefaultMessage;
 use Bernard\Producer;
 use Bernard\Message\PlainMessage;
 use Bernard\QueueFactory\InMemoryFactory;
@@ -65,16 +66,5 @@ class ProducerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($envelope->isDelayed());
         $this->assertEquals(10, $envelope->getDelay());
-    }
-
-    public function testItUsesGivenQueueName()
-    {
-        $message = new PlainMessage('SendNewsletter');
-
-        $this->producer->produce($message, 'something-else');
-
-        $envelope = $this->queues->create('something-else')->dequeue();
-
-        $this->assertSame($message, $envelope->getMessage());
     }
 }

--- a/tests/ProducerTest.php
+++ b/tests/ProducerTest.php
@@ -43,6 +43,18 @@ class ProducerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($message, $envelope->getMessage());
     }
 
+    public function testWithDelay()
+    {
+        $message = new DefaultMessage('SendNewsletter');
+
+        $this->producer->produce($message, null, 10);
+
+        $envelope = $this->queues->create('send-newsletter')->dequeue();
+
+        $this->assertTrue($envelope->isDelayed());
+        $this->assertEquals(10, $envelope->getDelay());
+    }
+
     public function testItUsesGivenQueueName()
     {
         $message = new PlainMessage('SendNewsletter');

--- a/tests/Queue/PersistentQueueTest.php
+++ b/tests/Queue/PersistentQueueTest.php
@@ -26,6 +26,32 @@ class PersistentQueueTest extends AbstractQueueTest
         $queue->enqueue($envelope);
     }
 
+    /**
+     * @expectedException Bernard\Exception\InvalidOperationException
+     * @expectedExceptionMessage This driver can't manage delayed messages
+     */
+    public function testEnqueueDelayedWithNotDelayableDriver()
+    {
+        $envelope = new Envelope($this->getMock('Bernard\Message'), 10);
+
+        $queue = $this->createQueue('send-newsletter');
+        $queue->enqueue($envelope);
+    }
+
+    public function testEnqueueDelayed()
+    {
+        $this->driver = $this->getMock('Bernard\DelayableDriver');
+        $envelope = new Envelope($this->getMock('Bernard\Message'), 10);
+
+        $this->serializer->expects($this->once())->method('serialize')->with($this->equalTo($envelope))
+            ->will($this->returnValue('serialized message'));
+        $this->driver->expects($this->once())->method('pushMessageWithDelay')
+            ->with($this->equalTo('send-newsletter'), $this->equalTo('serialized message'), $this->equalTo(10));
+
+        $queue = $this->createQueue('send-newsletter');
+        $queue->enqueue($envelope);
+    }
+
     public function testAcknowledge()
     {
         $envelope = new Envelope($this->createMock('Bernard\Message'));

--- a/tests/Queue/PersistentQueueTest.php
+++ b/tests/Queue/PersistentQueueTest.php
@@ -32,7 +32,7 @@ class PersistentQueueTest extends AbstractQueueTest
      */
     public function testEnqueueDelayedWithNotDelayableDriver()
     {
-        $envelope = new Envelope($this->getMock('Bernard\Message'), 10);
+        $envelope = new Envelope($this->createMock('Bernard\Message'), 10);
 
         $queue = $this->createQueue('send-newsletter');
         $queue->enqueue($envelope);
@@ -40,8 +40,8 @@ class PersistentQueueTest extends AbstractQueueTest
 
     public function testEnqueueDelayed()
     {
-        $this->driver = $this->getMock('Bernard\DelayableDriver');
-        $envelope = new Envelope($this->getMock('Bernard\Message'), 10);
+        $this->driver = $this->createMock('Bernard\DelayableDriver');
+        $envelope = new Envelope($this->createMock('Bernard\Message'), 10);
 
         $this->serializer->expects($this->once())->method('serialize')->with($this->equalTo($envelope))
             ->will($this->returnValue('serialized message'));

--- a/tests/QueueFactory/InMemoryFactoryTest.php
+++ b/tests/QueueFactory/InMemoryFactoryTest.php
@@ -6,6 +6,8 @@ use Bernard\QueueFactory\InMemoryFactory;
 
 class InMemoryFactoryTest extends \PHPUnit\Framework\TestCase
 {
+    private $factory;
+
     public function setUp()
     {
         $this->factory = new InMemoryFactory();

--- a/tests/QueueFactory/PersistentFactoryTest.php
+++ b/tests/QueueFactory/PersistentFactoryTest.php
@@ -6,6 +6,9 @@ use Bernard\QueueFactory\PersistentFactory;
 
 class PersistentFactoryTest extends \PHPUnit\Framework\TestCase
 {
+    private $factory;
+    private $connection;
+
     public function setUp()
     {
         $this->connection = $this->getMockBuilder('Bernard\Driver')


### PR DESCRIPTION
This branch add support for Delayable jobs and gives support for `symfony/event-dispatcher` v4.x (bumping  it's minimum version requirement)

There were incompatibilities with `count()` usages on `strings` and `null`, in relation to PHP7.2 changes on that function that were also fixed. (See https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types)

The goal for this PR is not merging, but keeping track  of custom changes needed from upstream version (in this case `1.0.0-alpha9`).

Branch `upstream-1.0.0-alpha9` mirrors `1.0.0-alpha9` tag, just for documenting this changeset in a PR.
